### PR TITLE
Bump gem version to 13.0.3

### DIFF
--- a/lib/bing/ads/version.rb
+++ b/lib/bing/ads/version.rb
@@ -1,5 +1,5 @@
 module Bing
   module Ads
-    VERSION = '13.0.2'.freeze
+    VERSION = '13.0.3'.freeze
   end
 end


### PR DESCRIPTION
We didn't update the version last time we made some changes to this repo. [history](https://github.com/clarisights/bing-ads/commits/master/)
Intended changes were mostly about error handling. Though the changes were tested locally, we might have to do one more round of testing in staging before updating the version in adwyze repo