### PR TITLE
feat: Treat AccountNotAuthorized as a typed exception

### DIFF
--- a/lib/bing/ads/api/errors.rb
+++ b/lib/bing/ads/api/errors.rb
@@ -34,6 +34,9 @@ module Bing
             super(message)
           end
         end
+
+        # Bing::Ads::API::Errors::AccountNotAuthorized
+        class AccountNotAuthorized < RuntimeError; end;
       end
     end
   end

--- a/lib/bing/ads/api/v13/services/base.rb
+++ b/lib/bing/ads/api/v13/services/base.rb
@@ -146,6 +146,10 @@ module Bing
               elsif fault_detail.dig(key, :operation_errors, :operation_error, :error_code) == 'BulkServiceNoMoreCallsPermittedForTheTimePeriod'
                 raise Bing::Ads::API::Errors::BulkApiRateLimitError,
                       'Rate limit exceeded. Please try again later.'
+              elsif fault_detail.dig(key, :operation_errors, :operation_error, :error_code) == 'AccountNotAuthorized'
+                raise Bing::Ads::API::Errors::AccountNotAuthorized,
+                      "Insufficient privileges to access one or more accounts in the report "\
+                      "request while calling #{operation}."
               else
                 raise Bing::Ads::API::Errors::UnhandledSOAPFault,
                       "SOAP error (#{fault_detail[key]}) while calling #{operation}."

--- a/lib/bing/ads/version.rb
+++ b/lib/bing/ads/version.rb
@@ -1,5 +1,5 @@
 module Bing
   module Ads
-    VERSION = '13.0.4'.freeze
+    VERSION = '13.0.5'.freeze
   end
 end


### PR DESCRIPTION
Add AccountNotAuthorized error class and map operation_error code 'AccountNotAuthorized' to it in handle_soap_fault. This allows callers to distinguish account privilege errors from generic SOAP faults, enabling proper user-failure classification.

Bump version: 13.0.4 -> 13.0.5