### PR TITLE
fix: Bump gem version post user perms error classification change

### DIFF
--- a/lib/bing/ads/version.rb
+++ b/lib/bing/ads/version.rb
@@ -1,5 +1,5 @@
 module Bing
   module Ads
-    VERSION = '13.0.5'.freeze
+    VERSION = '13.0.6'.freeze
   end
 end


### PR DESCRIPTION
Ref: https://github.com/clarisights/bing-ads/pull/14